### PR TITLE
Idwidth3

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -364,15 +364,8 @@ input {
     font-weight: bold;
 }
 
-/* Give id header an extra 10px left padding to compensate for 
- * 5px border and 5px left padding on content */
-.summary-list th.id a {
-    padding-left: 20px;
-}
-
 .id {
     width: 80px;
-    text-align: left;
 }
 
 p.no_items {
@@ -1196,12 +1189,6 @@ p.error404 {
 
     .summary-list td a, .summary-list th a {
         padding: 3px;
-    }
-
-    /* Give id header an extra 10px left padding to compensate for 
-     * 5px border and 5px left padding on content */
-    .summary-list th.id a {
-        padding-left: 13px;
     }
 
     .summary-list td, .summary-list th {


### PR DESCRIPTION
Final fixes on this now (hopefully). Turns out all I needed to do was to:
- convert table-layout from fixed to auto (to allow column width to grow dependent on row content), 
- stop making the id spans display as block elements (so that they can be as small as they need to be rather than filling the entire available width), and
- alter the span's padding to allow space for the icon on the right
