### PR TITLE
Idwidth3

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -465,7 +465,7 @@ li.summary-item {
    text-align:left;
 }
 
-.feedback {
+.summary-header .feedback {
     width: 8em;
 }
 


### PR DESCRIPTION
This pull request = [pull request 58](https://github.com/aptivate/econsensus/pull/58) + [fix](https://github.com/jogwen/econsensus/commit/3361b501fd364dc7015e4da4aa693e080742aac7) 

[pull request 58](https://github.com/aptivate/econsensus/pull/58) was merged and closed in github, but later reverted in aptivate/econsensus develop branch when Sarah noticed a bug introduced at 663edb94545cc3d9f9ea049d46835c5374129d47 where ".summary-header" was removed from a selector (intended for the feedback column in Proposal list view) inadvertently causing a width property to be applied to the form for adding new feedback). This new pull request now contains the fix for that bug (3361b501fd364dc7015e4da4aa693e080742aac7).
