### PR TITLE
Added jQuery update/deprecation warning for live() method to template

### DIFF
--- a/django/econsensus/publicweb/templates/item_detail.html
+++ b/django/econsensus/publicweb/templates/item_detail.html
@@ -21,6 +21,17 @@
 	<script type="text/javascript">
 	<!--
 	jQuery(function ($) {
+        {% comment %}
+        Deprecation_Note_re_live_method: Note regarding use of .live():
+        ===============================================================
+        - .live() method deprecated from jQuery v1.7, removed jQuery v1.9.
+        - When upgrading, note that suggested replacement method .on() is not a complete 
+        solution because .live() attaches events to all elements that match now *and 
+        in the future* and I believe that on() only applies to current matches. This is 
+        significant because many jQuery context objects of .live() in this template do not 
+        exist on initial page load.
+        {% endcomment %}
+
 		/*
 		 * Common functions
 		 */
@@ -99,12 +110,14 @@
 		 * Proposal in-line editing
 		 */
 		// Override redirect to form and put it inline
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$(".controls a.edit").live("click", function (e) {
 			replaceWithRemote("{% url 'publicweb_decision_snippet_update' object.id %}", "#decision_snippet_envelope");
 			e.preventDefault();
 		});
 	
 		// Override redirect to view and put it inline
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$('#decision_update_form input[value="Save"]').live("click", function (e) {
 			updateAndReplace("{% url 'publicweb_decision_update' object.id %}",
 							"{% url 'publicweb_decision_snippet_detail' object.id %}",
@@ -112,6 +125,7 @@
 			e.preventDefault();
 		});
 
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
         $('#decision_update_form input[value="Cancel"]').live("click", function (e) {
             e.stopPropagation();
             replaceWithRemote("{% url 'publicweb_decision_snippet_detail' object.id %}", 
@@ -132,17 +146,20 @@
 	
 		// Handle cancel manually, because it doesn't get submitted with
 		// javascript submission
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$('#feedback_add_anchor input[value="Cancel"]').live("click", function (e) {
 			e.stopPropagation();e.preventDefault();
 			$("#feedback_add_anchor form").replaceWith(feedback_button);
 		});
 	
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$(".button.add_feedback").live("click", function (e) {
             replaceWithRemote(feedback_add_url, ".button.add_feedback");
             scrollToFeedbackAnchor();
 			e.preventDefault();
 		});
 	
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
         $("#decision_detail .stats a dt").live("click", function (e) {
             var feedback_create_section = $('#feedback_add_anchor');
 
@@ -164,6 +181,7 @@
 			e.preventDefault();
 		});
 
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
         $('#id_rating').live("change", function (e) {
             var new_rating_value = $(this).val();
             var new_rating_name = e.currentTarget.form.rating.options[new_rating_value].text
@@ -172,6 +190,7 @@
                 new_rating_name);
         });
 	
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$("#feedback_add_anchor form").live("submit", function (e) {
 			var $form = $(this),
 				parameters = $form.serialize();
@@ -193,6 +212,7 @@
 		});
 	
 		// Override redirect to form and put it inline
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$(".feedback_list .description .edit").live("click", function (e) {
 			var wrapper = $(this).parents(".feedback_wrapper"),
 				object_id = wrapper.parent().attr("id").slice(2),
@@ -204,6 +224,7 @@
 		});
 	
 		// Override redirect to view and put it inline
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
         $('.feedback_list .feedback_form input[value="Cancel"]').live("click", function (e) {
             e.stopPropagation();
             e.preventDefault();
@@ -214,6 +235,7 @@
             replaceWithRemote(snippet_detail_url, feedback_form);
             e.preventDefault();
         });
+        {% comment %} .live() - see Deprecation_Note_re_live_method {% endcomment %}
 		$('.feedback_list .feedback_form').live("submit", function (e) {
 			var $this = $(this),
 				object_id = $this.parent().attr("id").slice(2),


### PR DESCRIPTION
Added django comment warning about potential gotcha regarding upgrading jQuery to a version where .live() method is deprecated/removed.
