### PR TITLE
Fix for bug in Action Item list screen: SQL syntax error when there are

### DIFF
--- a/django/econsensus/publicweb/views.py
+++ b/django/econsensus/publicweb/views.py
@@ -512,11 +512,7 @@ class EconsensusActionitemListView(ActionItemListView):
 
     def get_queryset(self):
         qs = ActionItem.objects \
-                .filter(origin__organization=self.organization) \
-                #.extra(select={'is_done': "CASE WHEN DATE() >= completed_on THEN 1 ELSE 0 END"})
-                # DATE() not compatible with MySQL so actionitems list screen errors when >0 objects.
-                # Could fix for MySQL by switching to CURDATE(), but should avoid .extra entirely if 
-                # possible, to keep app independent of the database engine.
+                .filter(origin__organization=self.organization)
         if self.sort_field in self.sort_by_alpha_fields:
             qs = qs.extra(select={'lower': "lower(" + self.sort_field + ")"}).order_by(self.sort_order + 'lower')
         else:


### PR DESCRIPTION
1 or more Action Items in system.
Cause was a .extra() containing a sqlite-compatible 'DATE()', which is
not compatible with MySQL. Could fix for MySQL, but this may or may not
break for sqlite, so need to avoid use of .extra() if possible.
