### PR TITLE
Fix text colours on discussion list screen:

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -320,15 +320,15 @@ input {
 	color: #000;
 }
 
-.summary-header .sort-asc, .sort-desc {
+.summary-header .sort-asc, .summary-header .sort-desc {
     color: #3E6EA3;
 }
 
-.discussion-list .sort-asc, .sort-desc {
+.discussion-list .sort-asc, .discussion-list .sort-desc {
     color: #000;
 }
 
-.discussion-list span {
+.discussion-list th > a > span {
     color: #FFF;
 }
 


### PR DESCRIPTION
- narrow down selector for white text for spans to table heading anchors only
- narrow down selector for black text for .sort-desc elements to
  discussion-list only (was causing .sort-desc elements on other list
  screens to be black as well)
- narrow down the other selector for .sort-desc to .summary-header only
  - has no effect on screens but might help avoid similar copy+paste errors in future!
    https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1222689
