### PR TITLE
added separator between organization name and Admin link

### DIFF
--- a/django/econsensus/publicweb/templates/organizations/organization_list.html
+++ b/django/econsensus/publicweb/templates/organizations/organization_list.html
@@ -17,7 +17,7 @@ Your Organizations
     {% for organization in organizations %}
     <li><a href="{% url 'publicweb_item_list' organization.slug 'proposal'%}">{{ organization }}</a>
     {% if organization.owner == user %}<span class="org-owner">Owner</span>{% endif %}
-    {% if organization|is_admin:user %}<span class="org-admin"><a href="{{ organization.get_absolute_url }}">Admin</a></span>{% endif %}
+    {% if organization|is_admin:user %}<span class="org-admin"><a href="{{ organization.get_absolute_url }}">| Admin</a></span>{% endif %}
     </li>
     {% empty %}
     <p>{% trans "You do not belong to any organizations."%}</p>


### PR DESCRIPTION
This is the same way that the header ("Your Organizations | Logout (username)") is split up. Seems to do the trick.

If the user is an administrator of lots of organizations then the 'Admin' links won't be aligned, for example

Ron's Brilliant Team | Admin
Tree Club | Admin
Cloud and Rain Society | Admin

So possibly it would make sense to have the two links in separate columns of a table to make them align. Let me know if you think this would be better.
