### PR TITLE
Password Reset Email more Verbose

### DIFF
--- a/django/econsensus/publicweb/templates/registration/password_reset_email.html
+++ b/django/econsensus/publicweb/templates/registration/password_reset_email.html
@@ -1,6 +1,6 @@
 {% load url from future %}
 {% load i18n %}
-{% blocktrans %}A password reset request has been made for your econsensus account.
+{% blocktrans %}A password reset request has been made for your {{ site_name }} account with username: {{ user }}.
 
 If you made this request, then please click on the link below to choose a new password:{% endblocktrans %}
 {% block reset_link %}

--- a/django/econsensus/publicweb/templates/registration/password_reset_subject.txt
+++ b/django/econsensus/publicweb/templates/registration/password_reset_subject.txt
@@ -1,1 +1,1 @@
-Econsensus password reset request
+{{ site_name }} password reset request


### PR DESCRIPTION
Template password_reset_email template updated. Added password_reset_subject template.

Kanban ticket:
https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1194097

Changes discussed here: (initial commit removed site_name variable)
https://github.com/philmcmahon/econsensus/commit/3fe9593298f4de5e30130f8dc2af6bdc2319ac22

The templates produce an email like this:
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: localhost password reset request
From: econsensus@econsensus.org
To: 123@123.com
Date: Sun, 31 Mar 2013 09:12:08 -0000
Message-ID: 20130331091208.30188.60503@phil-ubuntu

A password reset request has been made for your localhost account with username: phil.

If you made this request, then please click on the link below to choose a new password:

http://127.0.0.1:8000/accounts/password/reset/confirm/3-3g8-49f6f5e6a00b418a861e/

If you did not ask to reset your password, please ignore this email. No changes will be made to your account.
