### PR TITLE
Redirect to the correct list on adding Decision

### DIFF
--- a/django/econsensus/publicweb/views.py
+++ b/django/econsensus/publicweb/views.py
@@ -355,7 +355,7 @@ class DecisionCreate(CreateView):
         return context
 
     def get_success_url(self, *args, **kwargs):
-        return reverse('publicweb_item_list', args=[self.organization.slug, self.status])
+        return reverse('publicweb_item_list', args=[self.organization.slug, self.object.status])
 
     def post(self, *args, **kwargs):
         if self.request.POST.get('submit', None) == "Cancel":


### PR DESCRIPTION
Fixes #111

Haven't got the tests running yet, but `get_success_url()` is only called after successfully adding a `Decision`, so `self.object` will always be set.  
