### PR TITLE
Feedback rating names need to be known to the internationalisation

### DIFF
--- a/django/econsensus/publicweb/models.py
+++ b/django/econsensus/publicweb/models.py
@@ -8,6 +8,7 @@ from notification import models as notification
 from django.db import models
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_noop
 from django.contrib.auth.models import User
 from django.contrib.comments.models import Comment
 from django.contrib.contenttypes import generic
@@ -178,7 +179,11 @@ class Decision(models.Model):
         
 class Feedback(models.Model):
 
-    rating_names = (_('question'), _('danger'), _('concerns'), _('consent'), _('comment'))
+    rating_names = (ugettext_noop('question'),
+                    ugettext_noop('danger'),
+                    ugettext_noop('concerns'),
+                    ugettext_noop('consent'),
+                    ugettext_noop('comment'))
 
     RATING_CHOICES = [(rating_names.index(x), x) for x in rating_names]
     


### PR DESCRIPTION
system, since they can appear in the UI, but they shouldn't be
translated within the Feedback model class itself. (Fix for
http://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1656489)
