### PR TITLE
Don't override LOGIN_URL and LOGIN_REDIRECT_URL in local settings.

### DIFF
--- a/django/econsensus/local_settings.py.dev_fasttests
+++ b/django/econsensus/local_settings.py.dev_fasttests
@@ -3,9 +3,6 @@ import private_settings
 DEBUG = True
 TEMPLATE_DEBUG = True
 
-LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = 'item/list/proposal/'
-
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 DATABASES = {

--- a/django/econsensus/local_settings.py.production
+++ b/django/econsensus/local_settings.py.production
@@ -3,9 +3,6 @@ import private_settings
 DEBUG = False
 TEMPLATE_DEBUG = False
 
-LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = '/organizations/'
-
 STATIC_URL = '/static/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/django/econsensus/local_settings.py.staging
+++ b/django/econsensus/local_settings.py.staging
@@ -3,9 +3,6 @@ import private_settings
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = '/organizations/'
-
 STATIC_URL = '/static/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
This is a fix for
https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1385283
but the value for LOGIN_REDIRECT_URL now used is the one suggested by
https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1251883
