### PR TITLE
Fixes to notification email about joining organization

### DIFF
--- a/django/econsensus/publicweb/templates/organizations/email/notification_body.html
+++ b/django/econsensus/publicweb/templates/organizations/email/notification_body.html
@@ -1,9 +1,7 @@
 {% load url from future %}
 
-You have been made a member of {{ organization }} on {{ domain.name }}{% if sender %} by {{ sender.first_name }} {{ sender.last_name }}{% endif %}.
+You have been made a member of {{ organization }} on {{ domain.name }}{% if sender %} by {{ sender.username }}{% endif %}.
 
 Follow this link to see all your organizations.
 
 http://{{ domain.domain }}{% url 'organization_list' %}
-
-If you are unsure about this link please contact the sender.


### PR DESCRIPTION
There was a suggestion in the card, which I haven't implemented, to have a special help email address for an econsensus installation. (I'm not quite sure what status the suggestion had.)
