### PR TITLE
Allow multiple feedback forms to be open at once

### DIFF
--- a/django/econsensus/publicweb/templates/item_detail.html
+++ b/django/econsensus/publicweb/templates/item_detail.html
@@ -218,7 +218,7 @@
 				object_id = wrapper.parent().attr("id").slice(2),
 				snippet_update_url = snippet_update_url_template.replace('0', object_id);
 	
-			$('.feedback_list input[value="Cancel"]').click(); // Close open feedback first
+			// $('.feedback_list input[value="Cancel"]').click(); // Close open feedback first
 			replaceWithRemote(snippet_update_url, wrapper);
 			e.preventDefault();
 		});


### PR DESCRIPTION
(fix for https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1133869)

The javascript to close any open feedback forms when opening a new one has been commented out (in line with what was said on the kanban card)
