### PR TITLE
Create a small gap between feedback replies

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -1033,6 +1033,10 @@ div#tags {
 	margin-top: 1em;
 	}
 
+.contrib_comment {
+	margin-bottom: 0.25em;
+}
+
 .form_comment {
 	display :none;
 	}


### PR DESCRIPTION
This commit creates a small gap between feedback replies, which are currently squashed together.
