### PR TITLE
Allow comments to be added to feedback without javascript

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -1033,9 +1033,9 @@ div#tags {
 	margin-top: 1em;
 	}
 
-.form_comment {
+.showable {
 	display :none;
-	}
+}
 
 .form_comment textarea {
 	width: 100%;

--- a/django/econsensus/publicweb/static/js/showhide.js
+++ b/django/econsensus/publicweb/static/js/showhide.js
@@ -1,23 +1,23 @@
 /*
-Show/hide the feedback_comment class amongst multiple,
+Show/hide the showable class amongst multiple,
 with activation via a show button
 Objects are automatically hidden if the 
 user clicks outside the area
 */
   $(document).ready(function() {
     $("body").live("click", function() {
-      $(".form_comment").hide();
+      $(".showable").hide();
     });
     
     $(".show").live("click", function(e) {
-    var this_comment_form  = $(this).parent().siblings().find(".form_comment");
-      $(".form_comment").hide();
-      this_comment_form.show();
+    var this_showable_thing  = $(this).parent().siblings().find(".showable");
+      $(".showable").hide();
+      this_showable_thing.show();
       e.stopPropagation();
       e.preventDefault();
     });
     
-    $(".form_comment").live("click", function(e) {
+    $(".showable").live("click", function(e) {
       e.stopPropagation();
     });
   });

--- a/django/econsensus/publicweb/templates/feedback_comment_page.html
+++ b/django/econsensus/publicweb/templates/feedback_comment_page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Comment" %}{% endblock %}
+
+{% block heading %}{% trans "Comment" %}{% endblock %}
+
+{% block main_content %}
+    {% include "feedback_comment_snippet.html" %}
+{% endblock %}

--- a/django/econsensus/publicweb/templates/feedback_comment_snippet.html
+++ b/django/econsensus/publicweb/templates/feedback_comment_snippet.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% load comments %}
+
+{% with object.get_parent_url as next %}
+    {% render_comment_form for object %}
+{% endwith %}

--- a/django/econsensus/publicweb/templates/feedback_detail_snippet.html
+++ b/django/econsensus/publicweb/templates/feedback_detail_snippet.html
@@ -18,7 +18,7 @@
 	  <p>{{ object.description|urlize|linebreaksbr }}</p>
 {% if "edit_decisions_feedback" in organization_permissions %}
 	  <a class="edit" href='{% url 'publicweb_feedback_update' object.id %}'>{% trans "Edit" %}</a>
-	  <a class="show" href='#'>Comment</a>
+	  <a class="show" href='{% url 'publicweb_feedback_comment' object.id %}'>Comment</a>
 {% endif %}
 	</div>
 		
@@ -32,9 +32,9 @@
 		  {% endfor %}
 	  </ul>
 
-      {% with object.get_parent_url as next %}
-	  {% render_comment_form for object %}
-	  {% endwith %}
+        <div class="showable">
+	    {% include "feedback_comment_snippet.html" %}
+        </div>
     </div>
   </div>
 </li>

--- a/django/econsensus/publicweb/urls.py
+++ b/django/econsensus/publicweb/urls.py
@@ -27,6 +27,11 @@ urlpatterns = patterns('econsensus.publicweb.views',
             model = Feedback,
             template_name = 'feedback_detail_page.html')),
         name='publicweb_feedback_detail'),
+    url(r'^feedback/comment/(?P<pk>[\d]+)/$', 
+        login_required(DetailView.as_view(
+            model = Feedback,
+            template_name = 'feedback_comment_page.html')),
+        name='publicweb_feedback_comment'),
     #snippets
     url(r'^feedback/create/snippet/(?P<parent_pk>[\d]+)/$', 
         FeedbackSnippetCreate.as_view(template_name = 'feedback_update_snippet.html'),


### PR DESCRIPTION
Add page for adding comment to feedback, for use when javascript is disabled.

Make the show/hide logic for comment form hinge on "showable" class rather
than "form_comment" so that the form is always displayed on comment page.
(Fix for https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1128515)
