### PR TITLE
Fix DecisionLastModifiedTest's reliance on datetimes being stored with sub-second precision

### DIFF
--- a/deploy/pip_packages.txt
+++ b/deploy/pip_packages.txt
@@ -20,3 +20,4 @@ django-registration==1.0
 git+git://github.com/aptivate/django-notification.git@emails-with-headers
 django-guardian==1.1.1
 factory-boy==2.1.1
+MiniMock==1.2.8

--- a/django/econsensus/publicweb/tests/model_test.py
+++ b/django/econsensus/publicweb/tests/model_test.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 from django.test import TestCase
 
 from notification import models as notification
@@ -11,6 +12,9 @@ from publicweb.tests.factories import DecisionFactory, \
                                         UserFactory, \
                                         CommentFactory
 
+import datetime
+import minimock
+
 class DecisionLastModifiedTest(TestCase):
     """
     Tests updating of 'last_modified' date on Decision.
@@ -18,6 +22,19 @@ class DecisionLastModifiedTest(TestCase):
     def setUp(self):
         self.user = UserFactory()
         self.decision = DecisionFactory()
+
+        # Ensure value of "now" always increases by amount sufficient
+        # to show up as a change, even if db resolution for datetime
+        # is one second.
+        def now_iter(start):
+            t = start
+            while True:
+                t += datetime.timedelta(hours=1)
+                yield t
+        minimock.mock("timezone.now", returns_iter=now_iter(timezone.now()), tracker=None)
+
+    def tearDown(self):
+        minimock.restore()
 
     def last_modified(self):
         """


### PR DESCRIPTION
This was OK in development (using sqlite) but not on jenkins (using MySQL).

The new approach is to mock the function used by Django for getting the current time, so that we can make time in the test appear to move sufficiently fast that this is no longer a problem.
