### PR TITLE
Fix django-registration version

### DIFF
--- a/deploy/pip_packages.txt
+++ b/deploy/pip_packages.txt
@@ -11,7 +11,7 @@ django-debug-toolbar
 django-tagging
 hg+https://bitbucket.org/bkroeze/django-livesettings
 django-keyedcache
-django-registration
+django-registration==0.8
 -e ../django/django-organizations
 git+git://github.com/aptivate/django-notification.git@emails-with-headers
 django-guardian


### PR DESCRIPTION
Site only works with version 0.8, so specify this in
pip_packages, otherwise clean install will fetch latest,
which doesn't work.
