### PR TITLE
Show user permissions in user list

### DIFF
--- a/django/econsensus/publicweb/templates/organizations/organizationuser_list.html
+++ b/django/econsensus/publicweb/templates/organizations/organizationuser_list.html
@@ -2,6 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 {% load org_tags %}
+{% load publicweb_filters %}
 
 {% block title %}
 {{ organization }}'s members
@@ -25,6 +26,7 @@
     <td>{{ organization_user.user.first_name }}</td> 
     <td>{{ organization_user.user.last_name }}</td> 
     <td>{{ organization_user.user.email }}</td> 
+    <td>{{ organization|get_user_permissions:organization_user }}</td>
     <td><a href="{% url 'organization_user_edit' organization.id organization_user.user.id %}">edit</a> | <a href="{% url 'organization_user_delete' organization.id organization_user.user.id %}">delete</a></td>
 </tr>
 

--- a/django/econsensus/publicweb/templatetags/publicweb_filters.py
+++ b/django/econsensus/publicweb/templatetags/publicweb_filters.py
@@ -18,3 +18,11 @@ def get_rating_name(value):
 def get_user_name_from_comment(value):
     return (value.user and value.user.username) or value.user_name or "An Anonymous Contributor"
 
+@register.filter
+def get_user_permissions(org, org_user):
+    if org_user.user.is_active:
+        is_editor = org_user.user.has_perm('edit_decisions_feedback', org)
+        return ((('observer', 'editor')[is_editor], 'admin')[org_user.is_admin],
+            'owner')[org.is_owner(org_user.user)]
+    else:
+        return 'inactive'

--- a/django/econsensus/publicweb/tests/templatetags_test.py
+++ b/django/econsensus/publicweb/tests/templatetags_test.py
@@ -1,11 +1,27 @@
 from django.contrib.comments.models import Comment
 from django.test import TestCase
 
+from guardian.shortcuts import assign_perm
+
+from organizations.models import Organization
+from organizations.models import OrganizationUser
+
 from publicweb.templatetags import publicweb_filters
 from publicweb.tests.factories import UserFactory
 
 class CustomTemplateFilterTest(TestCase):
- 
+
+    fixtures = ['users.json', 'organizations.json']
+
+    def setUp(self):
+    	self.countrycritters = Organization.objects.get(name="Country Critters")
+        self.harry = OrganizationUser.objects.get(pk=12)
+        self.betty = OrganizationUser.objects.get(pk=13)
+        self.charlie = OrganizationUser.objects.get(pk=14)
+        self.debbie = OrganizationUser.objects.get(pk=15)
+        self.zarathustra = OrganizationUser.objects.get(pk=37)
+        
+
     def test_get_user_name_from_comment(self):
         comment = Comment(user=None, user_name='')
         self.assertEqual(publicweb_filters.get_user_name_from_comment(comment), "An Anonymous Contributor")
@@ -14,3 +30,11 @@ class CustomTemplateFilterTest(TestCase):
         user = UserFactory()
         comment.user = user
         self.assertEqual(publicweb_filters.get_user_name_from_comment(comment), user.username)
+
+    def test_get_user_permissions(self):
+    	self.assertEqual('owner', publicweb_filters.get_user_permissions(self.countrycritters, self.harry))
+    	self.assertEqual('admin', publicweb_filters.get_user_permissions(self.countrycritters, self.betty))
+    	assign_perm('edit_decisions_feedback', self.charlie.user, self.countrycritters)
+    	self.assertEqual('editor', publicweb_filters.get_user_permissions(self.countrycritters, self.charlie))
+    	self.assertEqual('observer', publicweb_filters.get_user_permissions(self.countrycritters, self.debbie))
+    	self.assertEqual('inactive', publicweb_filters.get_user_permissions(self.countrycritters, self.zarathustra))


### PR DESCRIPTION
Kanban ticket: https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1698335
(Original description: https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-1617009)

User permissions added using a template filter. At the moment there is no 'user type' - each user just is_admin/has the edit permission/is the owner so the filter works out the user type based on these values. Let me know of any changes that need to be made!
