### PR TITLE
Prevent multiple submission of feedback

### DIFF
--- a/django/econsensus/publicweb/static/js/clickonce.js
+++ b/django/econsensus/publicweb/static/js/clickonce.js
@@ -1,0 +1,10 @@
+/*
+Disables an element (e.g. submit button) of
+the "once" class the first time it is clicked
+*/
+$(document).on("click", ".once", function(e) {
+    if (this.has_been_clicked)
+        e.preventDefault();
+    else
+        this.has_been_clicked = true;
+});

--- a/django/econsensus/publicweb/templates/item_detail.html
+++ b/django/econsensus/publicweb/templates/item_detail.html
@@ -17,6 +17,7 @@
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}js/showhide.js"></script>
+	<script type="text/javascript" src="{{ STATIC_URL }}js/clickonce.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}js/parsley.min.js"></script>
 	<script type="text/javascript">
 	<!--


### PR DESCRIPTION
(fix for http://aptivate.kanbantool.com/boards/5986#tasks-1125291)

I'm not using the 'disabled' flag on the submission button in this version of the fix, because doing so gives different behaviour on firefox and chrome.
