### PR TITLE
Update all feedback counters

### DIFF
--- a/django/econsensus/publicweb/templates/item_detail.html
+++ b/django/econsensus/publicweb/templates/item_detail.html
@@ -46,15 +46,19 @@
 		}
 
 		function updateCounters() {
-			var counters = {},
-			    feedback_type;
+			var counters = {};
+			$(".stats dt").each(function () {
+				var type = this.className;
+				counters[type] = 0;
+			});
 			$(".feedback_type").each(function () {
 				var type = $.trim(this.className.replace("feedback_type", ""));
-				counters[type] = counters[type] ? counters[type]+1 : 1;
+				counters[type] = counters[type]+1;
 			});
-			for(feedback_type in counters) {
-				$(".stats ."+feedback_type).next()
-						.html(counters[feedback_type]);
+			for(var feedback_type in counters) {
+				var dt = $(".stats ."+feedback_type);
+				var dd = dt.next();
+				dd.html(counters[feedback_type]);
 			}
 		}
 


### PR DESCRIPTION
This is further work for https://aptivate.kanbantool.com/boards/5986-econsensus#tasks-995535

Although updateCounters() is now being called when a feedback changes type, further testing showed that the implementation of updateCounters() itself didn't always do the right thing.
