### PR TITLE
Add References: email header for better threading

### DIFF
--- a/django/econsensus/publicweb/tests/notification_test.py
+++ b/django/econsensus/publicweb/tests/notification_test.py
@@ -385,6 +385,7 @@ class NotificationTest(DecisionTestCase):
         self.assertTrue(outbox[0].extra_headers)
         self.assertEqual(outbox[0].extra_headers['Message-ID'], feedback.get_message_id())
         self.assertEqual(outbox[0].extra_headers['In-Reply-To'], feedback.decision.get_message_id())
+        self.assertEqual(outbox[0].extra_headers['References'], feedback.decision.get_message_id())
         mail.outbox = []
 
         self.login('charlie')
@@ -395,6 +396,7 @@ class NotificationTest(DecisionTestCase):
         self.assertTrue(outbox[0].extra_headers)
         self.assertEqual(outbox[0].extra_headers['Message-ID'], feedback.get_message_id())
         self.assertEqual(outbox[0].extra_headers['In-Reply-To'], feedback.decision.get_message_id())
+        self.assertEqual(outbox[0].extra_headers['References'], feedback.decision.get_message_id())
 
 class DecisionNotificationTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
particularly for comments.

The References: header has a list of all message-id:s of messages that
have come before it, so it allows threading even if the last message
wasn't received by you (as it wouldn't be if you entered it yourself on
the site).

Before this, if you enter a feedback on the site, then comments to the
feedback won't find the message-id referenced in the In-Reply-To:
header, so the comment email will start a new thread.
