### PR TITLE
Bug Fix

### DIFF
--- a/django/econsensus/publicweb/templates/organizations/organization_list.html
+++ b/django/econsensus/publicweb/templates/organizations/organization_list.html
@@ -34,7 +34,7 @@
             </li>
             {% endif %}
             <li>
-                <a href="{% url 'notification_settings' organization.pk %}">{% trans "notification settings" %}</a>
+                <a href="{% url 'notification_settings' organization.slug %}">{% trans "notification settings" %}</a>
             </li>
             <li>
                 <a href="{% url 'organization_user_leave' organization.pk %}">{% trans "leave" %}</a>


### PR DESCRIPTION
Fix a bug where the notification settings link for organisations used the primary key instead of the slug
