### PR TITLE
Watch tickbox

### DIFF
--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -111,7 +111,7 @@ a.button {
 	top:0.2em;
 }
 
-a.toggle {
+.toggle-link {
        line-height: 2.5em;
        color: #000;
        position: relative;
@@ -451,7 +451,7 @@ input {
 	color: #000;
 }
 
-.summary-list td a.toggle {
+.summary-list td .toggle-link {
 	display: inline;
 	padding: 0;
 }

--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -111,6 +111,16 @@ a.button {
 	top:0.2em;
 }
 
+a.toggle {
+       line-height: 2.5em;
+       color: #000;
+       position: relative;
+       padding: 1px 4px;
+       margin: 0;
+       top: 0.2em;
+       font-size: 0.9em;
+}
+
 textarea, input {
     border: 6px solid #ddd;
     -moz-border-radius: 10px;

--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -121,10 +121,6 @@ a.toggle {
        font-size: 0.9em;
 }
 
-a.toggle input {
-	cursor: pointer;
-}
-
 textarea, input {
     border: 6px solid #ddd;
     -moz-border-radius: 10px;

--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -154,6 +154,14 @@ input {
     cursor: pointer;
 }
 
+/* Sighted users do not need to see table header information repeated in links in each row. Users who instead jump from link to link may do. Use this class to markup such information. */
+.additional-table-link-caption {
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    position: absolute;
+    left: -1000px;
+}
 
 /* Main Blocks */
 

--- a/django/econsensus/publicweb/static/css/styles.css
+++ b/django/econsensus/publicweb/static/css/styles.css
@@ -121,6 +121,10 @@ a.toggle {
        font-size: 0.9em;
 }
 
+a.toggle input {
+	cursor: pointer;
+}
+
 textarea, input {
     border: 6px solid #ddd;
     -moz-border-radius: 10px;
@@ -449,6 +453,11 @@ input {
 	display: block;
 	padding: 10px;
 	color: #000;
+}
+
+.summary-list td a.toggle {
+	display: inline;
+	padding: 0;
 }
 
 .summary-list td .iconified {

--- a/django/econsensus/publicweb/templates/decision_detail_snippet.html
+++ b/django/econsensus/publicweb/templates/decision_detail_snippet.html
@@ -98,7 +98,7 @@
 			{% if "edit_decisions_feedback" in organization_permissions %}
 				<a class="edit button {{ object.status }}" href="{% url 'publicweb_decision_update' object.id %}">Edit</a>
 			{% endif %}
-            <a class="watch toggle {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %} {{ object.status }}"
+            <a class="watch toggle-link {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %} {{ object.status }}"
                href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}"
             >
                 {% if request.user|is_watching:object %}&#x2611;{% else %}&#x2610;{% endif %}

--- a/django/econsensus/publicweb/templates/decision_detail_snippet.html
+++ b/django/econsensus/publicweb/templates/decision_detail_snippet.html
@@ -1,6 +1,7 @@
 {% load url from future %}
 {% load i18n %}
 {% load guardian_tags %}
+{% load publicweb_filters %}
 
 {% if organization %}
 {% get_obj_perms request.user for organization as "organization_permissions" %}
@@ -93,11 +94,17 @@
             {% endfor %}
             {% endwith %}
 		</dl>
-{% if "edit_decisions_feedback" in organization_permissions %}		
-			<div class="controls">
+		<div class="controls">
+			{% if "edit_decisions_feedback" in organization_permissions %}
 				<a class="edit button {{ object.status }}" href="{% url 'publicweb_decision_update' object.id %}">Edit</a>
-			</div>
-{% endif %}
+			{% endif %}
+            <a class="watch toggle {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %} {{ object.status }}"
+               href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}"
+            >
+                <input class="watch {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %}" type="checkbox"{% if request.user|is_watching:object %} checked="True"{% endif %} />
+                {% trans "Watch" %}
+            </a>
+		</div>
 		</div>
 	</div>
 </div>

--- a/django/econsensus/publicweb/templates/decision_detail_snippet.html
+++ b/django/econsensus/publicweb/templates/decision_detail_snippet.html
@@ -101,7 +101,7 @@
             <a class="watch toggle {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %} {{ object.status }}"
                href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}"
             >
-                <input class="watch {% if request.user|is_watching:object %}watched{% else %}unwatched{% endif %}" type="checkbox"{% if request.user|is_watching:object %} checked="True"{% endif %} />
+                {% if request.user|is_watching:object %}&#x2611;{% else %}&#x2610;{% endif %}
                 {% trans "Watch" %}
             </a>
 		</div>

--- a/django/econsensus/publicweb/templates/decision_list.html
+++ b/django/econsensus/publicweb/templates/decision_list.html
@@ -66,7 +66,8 @@
                             {% if tab != 'actionitems' %}
                                 <td class="id"><a href="{% url 'publicweb_item_detail' object.id %}"><span class="iconified">{{ object.id }}</span></a></td>
                                 <td>
-                                    <a href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}">
+                                    <a class='toggle watch'
+                                       href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}">
                                         <input type="checkbox"{% if request.user|is_watching:object %} checked="True"{% endif %} />
                                     </a>
                                  </td>

--- a/django/econsensus/publicweb/templates/decision_list.html
+++ b/django/econsensus/publicweb/templates/decision_list.html
@@ -69,6 +69,9 @@
                                     <a class='toggle-link watch'
                                        href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}">
                                         {% if request.user|is_watching:object %}&#x2611;{% else %}&#x2610;{% endif %}
+                                        <span class='additional-table-link-caption'>
+                                            {% if request.user|is_watching:object %}{% trans "Watch" %}{% else %}{% trans "Unwatch" %}{% endif %} {{ object.excerpt }}
+                                        </span>
                                     </a>
                                  </td>
 				                <td class="excerpt"><a href="{% url 'publicweb_item_detail' object.id %}">{{ object.excerpt }}	</a></td>

--- a/django/econsensus/publicweb/templates/decision_list.html
+++ b/django/econsensus/publicweb/templates/decision_list.html
@@ -66,7 +66,7 @@
                             {% if tab != 'actionitems' %}
                                 <td class="id"><a href="{% url 'publicweb_item_detail' object.id %}"><span class="iconified">{{ object.id }}</span></a></td>
                                 <td>
-                                    <a class='toggle watch'
+                                    <a class='toggle-link watch'
                                        href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}">
                                         {% if request.user|is_watching:object %}&#x2611;{% else %}&#x2610;{% endif %}
                                     </a>

--- a/django/econsensus/publicweb/templates/decision_list.html
+++ b/django/econsensus/publicweb/templates/decision_list.html
@@ -68,7 +68,7 @@
                                 <td>
                                     <a class='toggle watch'
                                        href="{% if request.user|is_watching:object %}{% url 'remove_watcher' object.id %}{% else %}{% url 'add_watcher' object.id %}{% endif %}?next={{ request.path_info }}">
-                                        <input type="checkbox"{% if request.user|is_watching:object %} checked="True"{% endif %} />
+                                        {% if request.user|is_watching:object %}&#x2611;{% else %}&#x2610;{% endif %}
                                     </a>
                                  </td>
 				                <td class="excerpt"><a href="{% url 'publicweb_item_detail' object.id %}">{{ object.excerpt }}	</a></td>


### PR DESCRIPTION
- Add a watch tickbox on the detail page;
- Use an html entity for the tickbox rather than an input tag, as the latter approach fails on some browsers (at least in chromium)
- Stop the tickbox in the list table cell from expending it's clickable area to the whole cell.
