### PR TITLE
Tied django-livesettings commit

### DIFF
--- a/deploy/pip_packages.txt
+++ b/deploy/pip_packages.txt
@@ -15,7 +15,7 @@ lxml==2.2.4
 BeautifulSoup==3.2.0
 git+git://github.com/jdunck/python-unicodecsv.git
 django-tagging==0.3.1
-hg+https://bitbucket.org/bkroeze/django-livesettings
+-e hg+https://bitbucket.org/bkroeze/django-livesettings/@7e71fe2#egg=django-livesettings
 django-keyedcache==1.4-6
 django-registration==1.0
 -e ../django/django-organizations


### PR DESCRIPTION
I haven't fully investigated this yet but a couple of people have
reported a RECURSIVE_RELATIONSHIP_CONSTANT error in actionitems.

This seems to be due in part to an incompatibility with the latest
version of django-livesettings, which is generating an error about
config_register not being imported in publicweb/config.py. At some
point we're going to need to change this to:

from livesettings.functions import ...

The quickest fix is to tie our version of livesettings to a working
commit. This is probably good practice anyway.